### PR TITLE
Update Server.php

### DIFF
--- a/src/classes/Server.php
+++ b/src/classes/Server.php
@@ -205,6 +205,7 @@ class Server extends DBObject {
 		$arr['enabled'] = parseBool($arr['enabled']);
 		$arr['lastmodified'] = (int)$arr['lastmodified'];
 		$arr['id'] = (int)$arr['id'];
+		$arr['image'] = (int)$arr['image'];
 		asort($arr);
 		return $arr;
 	}


### PR DESCRIPTION
updated the server to Ubuntu 22.04 and php 8.1. The image id wasn't an int anymore on the POST:


"image":"7"

But GetServiceHash used it like this:

"image":7

Which resulted in different hashes, the one created and written down to the pxelinux.cfg file which was wrong and the one created on Preview Server which is correct.